### PR TITLE
Allow local, web-accessible file/directory imports

### DIFF
--- a/models/CsvImport/Import.php
+++ b/models/CsvImport/Import.php
@@ -735,8 +735,8 @@ class CsvImport_Import extends Omeka_Record_AbstractRecord
                         $dir = rtrim($file, " /\r\n");
                         $file = array();
                         foreach (scandir($dir) as $_file) {
-                            // ignore hidden files
-                            if (strpos($_file, '.') !== 0 && !in_array($_file, array('Thumbs.db'))) {
+                            // ignore sub-directories, hidden, and auto-generated files
+                            if (!is_dir($dir . '/' . $_file) && strpos($_file, '.') !== 0 && !in_array($_file, array('Thumbs.db'))) {
                                 $file[] = $dir . '/' . $_file;
                             }
                         }

--- a/models/CsvImport/Import.php
+++ b/models/CsvImport/Import.php
@@ -721,7 +721,7 @@ class CsvImport_Import extends Omeka_Record_AbstractRecord
                 $file = array($file);
             }
             // else check if it's on the webserver
-            elseif (is_dir($file) || is_file($file)) {
+            elseif (file_exists($file)) {
                 $source_type = 'Filesystem';
                 // make sure this file/directory is web accessible
                 if (strpos(realpath($file), BASE_DIR) === 0) {
@@ -766,14 +766,14 @@ class CsvImport_Import extends Omeka_Record_AbstractRecord
                     $f = insert_files_for_item($item, $source_type, $_file,
                         array('ignore_invalid_files' => false));
                 } catch (Omeka_File_Ingest_InvalidException $e) {
-                    $msg = "Invalid file URL '$url': "
+                    $msg = "Invalid file URL '$_file': "
                          . $e->getMessage();
                     $this->_log($msg, Zend_Log::ERR);
                     $item->delete();
                     release_object($item);
                     return false;
                 } catch (Omeka_File_Ingest_Exception $e) {
-                    $msg = "Could not import file '$url': "
+                    $msg = "Could not import file '$_file': "
                          . $e->getMessage();
                     $this->_log($msg, Zend_Log::ERR);
                     $item->delete();


### PR DESCRIPTION
Proposed resolution for #26.

Allows web-accessible files on the server (i.e. files in Omeka's doc root) to be imported if the full path is provided in the CSV Import.

Also allows the CSV Import to provide a directory, and all files in the directory will be imported for the respective item.