### PR TITLE
Skip blank rows

### DIFF
--- a/models/CsvImport/Import.php
+++ b/models/CsvImport/Import.php
@@ -678,6 +678,20 @@ class CsvImport_Import extends Omeka_Record_AbstractRecord
      */
     protected function _addItemFromRow($row)
     {
+        // check if this row is all blank cells
+        $blank = TRUE;
+        foreach ($row as $value) {
+            if (trim($value) !== '') {
+                $blank = FALSE;
+                break;
+            }
+        }
+        // if nothing but blank cells, skip this row
+        if ($blank) {
+            $this->_log('Blank row.', Zend_Log::ERR);
+            return FALSE;
+        }
+
         $result = $this->getColumnMaps()->map($row);
         $tags = $result[CsvImport_ColumnMap::TYPE_TAG];
         $itemMetadata = array(


### PR DESCRIPTION
Attempt at fixing Issue #71  . On CSV Import this code scans all values for a row, and if all values are empty strings, the row is skipped.

We've had this issue pop up a couple times in the past, and this fix seems to have resolved the issue.